### PR TITLE
[FIX] pos_longpolling: TypeError when reading preventDefault from undefined

### DIFF
--- a/pos_longpolling/static/src/js/LongpollingModel.js
+++ b/pos_longpolling/static/src/js/LongpollingModel.js
@@ -103,7 +103,7 @@ odoo.define("pos_longpolling.LongpollingModel", function(require) {
                         }
                     },
                     function(error, e) {
-                        e.preventDefault();
+                        if (e) e.preventDefault();
                         if (self.pos.debug) {
                             console.log(
                                 "POS LONGPOLLING send error",


### PR DESCRIPTION
NOTE: This module has been deprecated and removed in the original (forked) repo.
In any case, we won't use it anymore in recent versions of Odoo.